### PR TITLE
Update for changes to Scaleway's IPXE script

### DIFF
--- a/ubuntukernel-load.sh
+++ b/ubuntukernel-load.sh
@@ -44,7 +44,7 @@ rebuild_initrd() {
     local workdir=$(mktemp -d)
 
     # get original initrd url from IPXE
-    local orig_initrd=$(curl -s $SCW_IPXE_SCRIPT | grep ^initrd | cut -f2 -d" ")
+    local orig_initrd=$(curl -s $SCW_IPXE_SCRIPT | grep ^initrd | grep -P -o 'http://\S+')
     log "Scaleway initrd: $orig_initrd"
 
     log "+ get scaleway initrd"


### PR DESCRIPTION
Scaleway recently changed their `initrd` line to include a `--name`:

```
initrd --name initrd http://169.254.42.24/initrd/initrd-Linux-x86_64-v3.12.4.gz || goto error
```

The `orig_initrd` variable in the script was being incorrectly set to `--name` instead of the URL.